### PR TITLE
Sync file with PlutoEvent interface

### DIFF
--- a/julia-runtime/run.jl
+++ b/julia-runtime/run.jl
@@ -99,10 +99,12 @@ pluto_server_options = Pluto.Configuration.from_flat_kwargs(;
     # show_file_system=false,
     dismiss_update_notification = true,
     auto_reload_from_file = false,
+    disable_writing_notebook_files = true,
     (Symbol(k) => v for (k, v) in JSON.parse(pluto_launch_params))...)
+
 pluto_server_session = Pluto.ServerSession(;
     secret = secret,
-    options = pluto_server_options
+    options = pluto_server_options,
 )
 
 extensionData = PlutoExtensionSessionData(
@@ -118,6 +120,21 @@ function whenNotebookUpdates(path, newString)
     sendCommand(path, newString)
 end
 
+function event_listener(pe::Pluto.PlutoEvent)
+    @info "Overriden PlutoEvent for"  pe.path
+end
+
+function event_listener(pe::Pluto.FileSaveEvent)
+    @info "Overriden filesave event for" pe.path
+    id = string(pe.notebook.notebook_id)
+    oldContent = get(extensionData.textRepresentations, id, "")
+    if oldContent != pe.fileContent
+        whenNotebookUpdates(pe.path, pe.fileContent)
+        extensionData.textRepresentations[id] = pe.fileContent
+    end
+end
+
+extensionData.session.event_listener =  event_listener
 ###
 @info "OPEN NOTEBOOK"
 
@@ -168,16 +185,6 @@ try ## Note: This is to assist with co-developing Pluto & this Extension
 catch
 end
 
-function registerOnFileSaveListener(notebook::Pluto.Notebook)
-    function onfilechange(pe::Pluto.PlutoEvent)
-        if pe isa Pluto.FileSaveEvent
-            whenNotebookUpdates(pe.path, pe.fileContent)
-        end
-    end
-    notebook.write_out_fs = false
-    notebook.listeners = [onfilechange, notebook.listeners...]
-end
-
 command_task = Pluto.@asynclog while true
     filenbmap = extensionData.notebooks
     new_command = getNextSTDINCommand()
@@ -202,7 +209,6 @@ command_task = Pluto.@asynclog while true
 
         jlpath = detail["fsPath"]  # joinpath(extensionData.jlfilesroot, detail["jlfile"])
         nb = Pluto.SessionActions.open(pluto_server_session, jlpath; notebook_id = UUID(detail["notebook_id"]))
-        registerOnFileSaveListener(nb)
         filenbmap[detail["jlfile"]] = nb
         generate_output(nb, editor_html_filename, vscode_proxy_root, frontend_params)
 

--- a/julia-runtime/run.jl
+++ b/julia-runtime/run.jl
@@ -134,6 +134,16 @@ function event_listener(pe::Pluto.FileSaveEvent)
     end
 end
 
+# function event_listener(pe::Pluto.FileLocalChangeEvent)
+#     @info "Overriden filesave event for" pe.path
+#     id = string(pe.notebook.notebook_id)
+#     oldContent = get(extensionData.textRepresentations, id, "")
+#     if oldContent != pe.fileContent
+#         whenNotebookUpdates(pe.path, pe.fileContent)
+#         extensionData.textRepresentations[id] = pe.fileContent
+#     end
+# end
+
 extensionData.session.event_listener =  event_listener
 ###
 @info "OPEN NOTEBOOK"

--- a/julia-runtime/run.jl
+++ b/julia-runtime/run.jl
@@ -128,9 +128,9 @@ function event_listener(pe::Pluto.FileSaveEvent)
     @info "Overriden filesave event for" pe.path
     id = string(pe.notebook.notebook_id)
     oldContent = get(extensionData.textRepresentations, id, "")
-    if oldContent != pe.fileContent
-        whenNotebookUpdates(pe.path, pe.fileContent)
-        extensionData.textRepresentations[id] = pe.fileContent
+    if oldContent != pe.file_contents
+        whenNotebookUpdates(pe.path, pe.file_contents)
+        extensionData.textRepresentations[id] = pe.file_contents
     end
 end
 
@@ -138,9 +138,9 @@ end
 #     @info "Overriden filesave event for" pe.path
 #     id = string(pe.notebook.notebook_id)
 #     oldContent = get(extensionData.textRepresentations, id, "")
-#     if oldContent != pe.fileContent
-#         whenNotebookUpdates(pe.path, pe.fileContent)
-#         extensionData.textRepresentations[id] = pe.fileContent
+#     if oldContent != pe.file_contents
+#         whenNotebookUpdates(pe.path, pe.file_contents)
+#         extensionData.textRepresentations[id] = pe.file_contents
 #     end
 # end
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "pluto-vscode",
     "displayName": "Pluto.jl (alpha preview)",
     "description": "Pluto.jl inside VS Code",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "publisher": "juliacomputing",
     "license": "MIT",
     "icon": "media/favicon_unsaturated_bg_512.png",

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -143,13 +143,13 @@ export class PlutoBackend {
             this._server.listen(await this.localport);
 
             this._process.stdout!.on("data", (data) => {
-                const text = data.slice(0, data.length - 1)
+                const text = data.slice(0)
 
                 console.log(`📈${text}`)
             })
 
             this._process.stderr!.on("data", (data) => {
-                const text = data.slice(0, data.length - 1)
+                const text = data.slice(0)
 
                 console.log(`📈${text}`)
                 // @info prints to stderr

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { TextDecoder, TextEncoder } from "util"
 import { v4 as uuid } from "uuid"
 
 // this is a commit on the vscode-webview-proxy branch, see https://github.com/fonsp/Pluto.jl/pull/1493
-export const PLUTO_BRANCH_NAME = "b1ada028a0c8a66de2cab211052681e05ed31203"
+export const PLUTO_BRANCH_NAME = "7f00dfd13ab19204fafa0a58d20c1808d0284d38"
 
 /*
 HELLO

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { TextDecoder, TextEncoder } from "util"
 import { v4 as uuid } from "uuid"
 
 // this is a commit on the vscode-webview-proxy branch, see https://github.com/fonsp/Pluto.jl/pull/1493
-export const PLUTO_BRANCH_NAME = "376b08851906afc9e52e2c09e823de8d7e656675"
+export const PLUTO_BRANCH_NAME = "12fc15932cbb6ac3bc83e4d758b590f168d069c9"
 
 /*
 HELLO

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { TextDecoder, TextEncoder } from "util"
 import { v4 as uuid } from "uuid"
 
 // this is a commit on the vscode-webview-proxy branch, see https://github.com/fonsp/Pluto.jl/pull/1493
-export const PLUTO_BRANCH_NAME = "12fc15932cbb6ac3bc83e4d758b590f168d069c9"
+export const PLUTO_BRANCH_NAME = "b1ada028a0c8a66de2cab211052681e05ed31203"
 
 /*
 HELLO


### PR DESCRIPTION
- [ ] Listen for file save events from Pluto and notify extension to save (almost done)
- [ ] Listen for file edit events and notify extension to apply change in the workspace
- [ ] Handle file rename/move (the old implementation stopped working)
- [ ] Persist VSCode refreshes/restarts (when remote is alive/if possible?)